### PR TITLE
Only include the AWS SDK Core packages

### DIFF
--- a/opentracing-aws-sdk-1/pom.xml
+++ b/opentracing-aws-sdk-1/pom.xml
@@ -29,8 +29,8 @@
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.600</version>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>1.11.619</version>
     </dependency>
 
     <dependency>
@@ -59,10 +59,7 @@
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-java-sdk-core</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.amazonaws</groupId>
-          <artifactId>aws-java-sdk-dynamodb</artifactId>
-        </exclusion>
+      
       </exclusions>
     </dependency>
   </dependencies>

--- a/opentracing-aws-sdk-2/pom.xml
+++ b/opentracing-aws-sdk-2/pom.xml
@@ -29,8 +29,8 @@
   <dependencies>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>aws-sdk-java</artifactId>
-      <version>2.7.15</version>
+      <artifactId>sdk-core</artifactId>
+      <version>2.7.32</version>
     </dependency>
 
     <dependency>
@@ -57,6 +57,12 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>DynamoDBLocal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb</artifactId>
+      <version>2.7.32</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
opentracing-aws-sdk included the entire AWS SDK distribution as dependencies. This seems unnecessary, as the TracingRequestHandler only really depends on sdk-core. Therefore, include only sdk-core as a direct dependency.

The dynamodb SDK is included as a test dependency so unittests pass.

Also upgrade versions of SDK 1 and SDK 2 to the current versions.