### PR TITLE
Set scope=provided

### DIFF
--- a/opentracing-aws-sdk-1/pom.xml
+++ b/opentracing-aws-sdk-1/pom.xml
@@ -31,6 +31,7 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
       <version>1.11.619</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -59,7 +60,7 @@
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-java-sdk-core</artifactId>
         </exclusion>
-      
+
       </exclusions>
     </dependency>
   </dependencies>

--- a/opentracing-aws-sdk-2/pom.xml
+++ b/opentracing-aws-sdk-2/pom.xml
@@ -31,6 +31,7 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
       <version>2.7.32</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Setting the scope of the target libraries of instrumentation to "provided". It is a guarantee that the integrating codebase will provide these libraries, otherwise the instrumentation plugin would be moot if the codebase does not already have these libraries.