### PR TITLE
do not forward OT headers to AWS service

### DIFF
--- a/opentracing-aws-sdk-1/src/main/java/io/opentracing/contrib/aws/TracingRequestHandler.java
+++ b/opentracing-aws-sdk-1/src/main/java/io/opentracing/contrib/aws/TracingRequestHandler.java
@@ -21,8 +21,6 @@ import com.amazonaws.handlers.RequestHandler2;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
-import io.opentracing.propagation.TextMapAdapter;
 import io.opentracing.tag.Tags;
 
 /**
@@ -65,9 +63,6 @@ public class TracingRequestHandler extends RequestHandler2 {
 
     Span span = spanBuilder.start();
     SpanDecorator.onRequest(request, span);
-
-    tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS,
-        new TextMapAdapter(request.getHeaders()));
 
     request.addHandlerContext(contextKey, span);
   }


### PR DESCRIPTION
Removed adding OT headers to requests from AWS SDK 1 to AWS service because

- enhancing the request from AWS SDK on the client to the server with OT headers can cause issues with the AWS signature calculation especially with baggage items having underscores
- OT headers can forward sensitive information from services to AWS
- AWS does not use OT but its own tracing system X-Ray and is not interested in OT headers
- OT headers are also not forwarded in the AWS SDK 2